### PR TITLE
Updated imports for Python 3 (Live 11 change).

### DIFF
--- a/Generic/Generic.py
+++ b/Generic/Generic.py
@@ -10,12 +10,12 @@ from _Framework.ChannelStripComponent import ChannelStripComponent
 from _Framework.DeviceComponent import DeviceComponent
 from _Framework.ControlSurfaceComponent import ControlSurfaceComponent
 from _Framework.SessionZoomingComponent import SessionZoomingComponent
-from SpecialMixerComponent import SpecialMixerComponent
-from SpecialTransportComponent import SpecialTransportComponent
-from SpecialSessionComponent import SpecialSessionComponent
-from SpecialZoomingComponent import SpecialZoomingComponent
-from SpecialViewControllerComponent import DetailViewControllerComponent
-from MIDI_Map import *
+from .SpecialMixerComponent import SpecialMixerComponent
+from .SpecialTransportComponent import SpecialTransportComponent
+from .SpecialSessionComponent import SpecialSessionComponent
+from .SpecialZoomingComponent import SpecialZoomingComponent
+from .SpecialViewControllerComponent import DetailViewControllerComponent
+from .MIDI_Map import *
 
 class Generic(ControlSurface):
     __doc__ = " Script for FCB1010 in APC emulation mode "

--- a/Generic/SpecialMixerComponent.py
+++ b/Generic/SpecialMixerComponent.py
@@ -1,5 +1,5 @@
 from _Framework.MixerComponent import MixerComponent
-from SpecialChannelStripComponent import SpecialChannelStripComponent
+from .SpecialChannelStripComponent import SpecialChannelStripComponent
 class SpecialMixerComponent(MixerComponent):
     ' Special mixer class that uses return tracks alongside midi and audio tracks '
     __module__ = __name__

--- a/Generic/SpecialTransportComponent.py
+++ b/Generic/SpecialTransportComponent.py
@@ -4,8 +4,8 @@ from _Framework.ButtonElement import ButtonElement
 from _Framework.EncoderElement import EncoderElement 
 from _Framework.SubjectSlot import subject_slot 
 
-from MIDI_Map import TEMPO_TOP
-from MIDI_Map import TEMPO_BOTTOM
+from .MIDI_Map import TEMPO_TOP
+from .MIDI_Map import TEMPO_BOTTOM
 class SpecialTransportComponent(TransportComponent):
     __doc__ = ' TransportComponent that only uses certain buttons if a shift button is pressed '
     def __init__(self):

--- a/Generic/__init__.py
+++ b/Generic/__init__.py
@@ -1,5 +1,5 @@
 import Live 
-from Generic import Generic 
+from .Generic import Generic 
 
 def create_instance(c_instance):
     ' Creates and returns the APC20 script '


### PR DESCRIPTION
My script wasn't loading in Live 11, which now works only with Python 3.

The Log.txt showed the other project modules weren't being detected so I added the `.` for every other file in the project.

At least in my case, these little revisions were all that's necessary for it to seem like my script works; it shows up in the MIDI prefs menu and the few functions I've tested work, although Log.txt still shows a Jenkins silent exception when I select that script from the menu. So, there may yet be smaller looming issues I haven't yet encountered.


Thanks for this work, I've found it very helpful to my workflow.